### PR TITLE
Change travis build to run on container infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,11 @@ rust:
   - beta
   - nightly
 
-sudo: required
-
-before_install:
-  - bash ./travis/install_cfitsio.sh
+addons:
+  apt:
+    packages:
+      - libcfitsio-dev
+      - libcfitsio-bin
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: rust
 script: bash ./test_all.sh
+sudo: false
 
 rust:
   - stable
@@ -9,8 +10,8 @@ rust:
 addons:
   apt:
     packages:
-      - libcfitsio-dev
-      - libcfitsio-bin
+      - libcfitsio3-dev
+      - pkg-config
 
 matrix:
   allow_failures:


### PR DESCRIPTION
There have been a lot of test failures due to a cfitsio bug with the filesystem. This PR is a test to see if that is fixed when running on the container infrastructure. Also this should speed up builds anyway.